### PR TITLE
Document reproduction workflow and portable CTRG manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ The system automatically generates Chinese brain CT reports by fine-tuning LLaMA
 ## Table of Contents
 
 1. [Architecture Overview](#architecture-overview)
-2. [Requirements](#requirements)
-3. [Pre-trained Models](#pre-trained-models)
-4. [Dataset Setup](#dataset-setup)
-5. [Data Preparation Pipeline](#data-preparation-pipeline)
-6. [Training](#training)
-7. [Evaluation](#evaluation)
-8. [Configuration Reference](#configuration-reference)
-9. [Hardcoded Paths — Action Required](#hardcoded-paths--action-required)
-10. [Citation](#citation)
+2. [Reproduction Quick Start](#reproduction-quick-start)
+3. [Requirements](#requirements)
+4. [Pre-trained Models](#pre-trained-models)
+5. [Dataset Setup](#dataset-setup)
+6. [Data Preparation Pipeline](#data-preparation-pipeline)
+7. [Training](#training)
+8. [Evaluation](#evaluation)
+9. [Configuration Reference](#configuration-reference)
+10. [Hardcoded Paths — Action Required](#hardcoded-paths--action-required)
+11. [Citation](#citation)
 
 ---
 
@@ -45,9 +46,45 @@ Each CT sample contains **24 slices** covering 8 anatomical layers (3 images per
 
 ---
 
+## Reproduction Quick Start
+
+The minimal workflow for reproducing the ViT-MLP-LLaMA baseline is:
+
+```bash
+git clone https://github.com/Chauncey-Jheng/PCRL-MRG.git
+cd PCRL-MRG
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# Download CTRG, then make the bundled 24-slice manifest portable.
+python data_peparation/prepare_image_manifest.py \
+  --dataset-root /path/to/CTRG-Brain \
+  --check
+
+# Edit the dataset/model paths listed below, then extract visual features.
+python data_peparation/get_visual_feature/clip_vit_1024.py
+
+# Fine-tune and evaluate.
+bash scripts/VIT_MLP_llama/finetuning_CTRG_MRG.sh
+bash scripts/VIT_MLP_llama/test_CTRG_MRG.sh
+```
+
+Before launching a long run, verify that the base model, generated manifest,
+visual feature directory, and output directory all point to your local paths.
+The original experiments use seed `3578` in the example training command.
+
+---
+
 ## Requirements
 
-No `requirements.txt` is included. Install the following core packages:
+A `requirements.txt` is included. Install it with:
+
+```bash
+pip install -r requirements.txt
+```
+
+To install the core packages manually instead:
 
 ```bash
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118
@@ -83,8 +120,37 @@ data_peparation/segment_anything/sam_vit_h_4b8939.pth
 ## Dataset Setup
 
 1. Download the CTRG dataset from https://github.com/tangyuhao2016/CTRG
-2. Place the raw images and annotation file (`origin_samples.json`) under a local directory, e.g. `/data/CTRG_dataset/`
-3. Pre-processed annotation files are already included in `dataset/` for reference
+2. Place the raw images under `<CTRG_ROOT>/samples/<sample_id>/*.jpg` and the annotation file under your local CTRG directory.
+3. Pre-processed annotations are included in `dataset/` for reference.
+4. Generate a local, portable copy of the 24-slice image manifest:
+
+```bash
+python data_peparation/prepare_image_manifest.py \
+  --dataset-root /path/to/CTRG-Brain \
+  --output /path/to/CTRG-Brain/total_image_list_final.json \
+  --check
+```
+
+### About `total_image_list_final.json`
+
+`dataset/total_image_list_final.json` is included in this repository. It maps
+each of the 6,001 CTRG sample IDs to the 24 slices selected in the original
+experiments. Its paths record the authors' machine and therefore cannot be used
+directly on another system. `prepare_image_manifest.py` preserves the original
+slice selection, replaces only the dataset root, and optionally checks that all
+24 files for every sample exist. It does **not** redistribute CTRG images; those
+must be downloaded separately under the CTRG license.
+
+The generated JSON has this schema:
+
+```json
+{
+  "sample_id": [
+    "/path/to/CTRG-Brain/samples/sample_id/slice_01.jpg",
+    "... 23 more paths ..."
+  ]
+}
+```
 
 ---
 

--- a/data_peparation/prepare_image_manifest.py
+++ b/data_peparation/prepare_image_manifest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Rebase the bundled CTRG 24-slice manifest onto a local dataset root."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INPUT = REPOSITORY_ROOT / "dataset" / "total_image_list_final.json"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Preserve the original 24-slice selection while replacing the "
+            "authors' absolute paths with paths under a local CTRG dataset."
+        )
+    )
+    parser.add_argument(
+        "--dataset-root",
+        required=True,
+        type=Path,
+        help="CTRG root containing samples/<sample_id>/*.jpg",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_INPUT,
+        help="Source manifest (default: repository's bundled manifest)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output path (default: <dataset-root>/total_image_list_final.json)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if a rebased image path is missing or a sample has != 24 slices",
+    )
+    return parser.parse_args()
+
+
+def rebase_manifest(manifest, dataset_root):
+    samples_root = dataset_root.expanduser().resolve() / "samples"
+    rebased = {}
+    for sample_id, image_paths in manifest.items():
+        rebased[str(sample_id)] = [
+            str(samples_root / str(sample_id) / Path(image_path).name)
+            for image_path in image_paths
+        ]
+    return rebased
+
+
+def validate_manifest(manifest):
+    errors = []
+    for sample_id, image_paths in manifest.items():
+        if len(image_paths) != 24:
+            errors.append(f"sample {sample_id}: expected 24 paths, found {len(image_paths)}")
+        missing = [path for path in image_paths if not Path(path).is_file()]
+        if missing:
+            errors.append(f"sample {sample_id}: {len(missing)} image(s) missing; first: {missing[0]}")
+    return errors
+
+
+def main():
+    args = parse_args()
+    output_path = args.output or args.dataset_root / "total_image_list_final.json"
+
+    with args.input.open("r", encoding="utf-8") as file:
+        source_manifest = json.load(file)
+    if not isinstance(source_manifest, dict):
+        raise SystemExit("Input manifest must be a JSON object keyed by sample ID")
+
+    manifest = rebase_manifest(source_manifest, args.dataset_root)
+    if args.check:
+        errors = validate_manifest(manifest)
+        if errors:
+            preview = "\n".join(errors[:20])
+            remainder = len(errors) - 20
+            if remainder > 0:
+                preview += f"\n... and {remainder} more error(s)"
+            raise SystemExit(f"Manifest validation failed:\n{preview}")
+
+    output_path = output_path.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as file:
+        json.dump(manifest, file, ensure_ascii=False, indent=2)
+        file.write("\n")
+    print(f"Wrote {len(manifest)} samples to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add an end-to-end reproduction quick start to the README
- document where `total_image_list_final.json` lives and why its bundled absolute paths must be rebased
- add `prepare_image_manifest.py` to preserve the original 24-slice selection while generating paths for a local CTRG checkout
- correct the README to use the existing `requirements.txt`

## Root cause

The selected-slice manifest was present in the repository, but it contained paths from the original development machine and the README did not explain how to make it usable elsewhere. The README also lacked a concise rerun sequence.

## Validation

- `python3 -m py_compile data_peparation/prepare_image_manifest.py`
- ran the generator with `--check` against the CTRG data on `frp_4090D`
- validated all 6,001 samples and all 24 selected image paths per sample
- `git diff --check`

Closes #5
Closes #6